### PR TITLE
config.txt: reintroduce start_x

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,7 +1,7 @@
 ################################################################################
 ##  Raspberry Pi Configuration Settings
 ##
-##  Revision 17, 2021/08/15
+##  Revision 18, 2023/11/20
 ##
 ##  Details taken from the eLinux wiki and official Raspberry Pi documentation.
 ##  For up-to-date information please refer to links below.
@@ -759,6 +759,16 @@
 ################################################################################
 ##  Camera Settings
 ################################################################################
+
+## start_x
+##     Set to "1" to enable the camera module.
+##
+##     Enabling the camera requires gpu_mem option to be specified with a value
+##     of at least 128.
+##
+##     Default 0
+##
+#start_x=0
 
 ## disable_camera_led
 ##     Turn off the red camera led when recording video or taking a still


### PR DESCRIPTION
Reintroduce configuration `start_x`. Based on the experience with Yocto/OpenEmbedded layer meta-raspberrypi, it has been observed that Raspberry Pi 4B 4GB may fail to enable the camera if `start_x=1` is at the end of the file. Therefore, `start_x=1` is expected in `config.txt` template and it has been set to replace the original occurrence, which is at the middle of the file. Also update revision and date stamp.

This change is based on the discussion https://github.com/agherzan/meta-raspberrypi/pull/1247